### PR TITLE
Duck Spotify volume while speaking instead of talking over it

### DIFF
--- a/BrowserExtension/manifest.json
+++ b/BrowserExtension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "VoxClaw",
-  "description": "Pauses YouTube when VoxClaw speaks, resumes when it finishes.",
-  "version": "1.0.0",
+  "description": "Pauses YouTube and ducks Spotify when VoxClaw speaks, restores when it finishes.",
+  "version": "1.1.0",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",
@@ -19,7 +19,8 @@
     "https://*.youtube.com/*",
     "https://youtube.com/*",
     "https://youtu.be/*",
-    "https://*.youtube-nocookie.com/*"
+    "https://*.youtube-nocookie.com/*",
+    "https://open.spotify.com/*"
   ],
   "action": {
     "default_title": "VoxClaw",

--- a/BrowserExtension/popup.html
+++ b/BrowserExtension/popup.html
@@ -31,7 +31,7 @@
   <h3>VoxClaw</h3>
   <label>
     <input type="checkbox" id="enabled" checked>
-    Pause YouTube while speaking
+    Pause YouTube &amp; duck Spotify while speaking
   </label>
   <div class="status" id="status">Checking...</div>
   <script src="popup.js"></script>

--- a/BrowserExtension/service_worker.js
+++ b/BrowserExtension/service_worker.js
@@ -1,8 +1,19 @@
 const POLL_INTERVAL_MS = 1000;
 const STATUS_URL = "http://localhost:4140/status";
 
+// Spotify ducking: lower playing tabs to this volume while speaking, with
+// short fades so it reads as ducking rather than a glitch. Restore is held
+// briefly because /status flips to not-reading during the queue's 1s
+// inter-item gap — without the hold, volume yo-yos between queued utterances.
+const DUCK_VOLUME = 0.2;
+const FADE_DOWN_MS = 300;
+const FADE_UP_MS = 500;
+const RESTORE_HOLD_MS = 1500;
+
 let wasReading = false;
 let pausedTabs = [];
+let duckedTabs = [];
+let restoreTimer = null;
 let pollTimer = null;
 
 function log(...args) {
@@ -27,10 +38,21 @@ async function pollStatus() {
     if (isReading && !wasReading) {
       pausedTabs = await pauseYouTube();
       log(`Speaking started, paused ${pausedTabs.length} tab(s)`);
-    } else if (!isReading && wasReading && pausedTabs.length > 0) {
-      await resumeYouTube(pausedTabs);
-      log(`Speaking finished, resumed ${pausedTabs.length} tab(s)`);
-      pausedTabs = [];
+      if (restoreTimer) {
+        // Speech resumed within the hold window — stay ducked.
+        clearTimeout(restoreTimer);
+        restoreTimer = null;
+      } else if (duckedTabs.length === 0) {
+        duckedTabs = await duckSpotify();
+        log(`Ducked ${duckedTabs.length} Spotify tab(s)`);
+      }
+    } else if (!isReading && wasReading) {
+      if (pausedTabs.length > 0) {
+        await resumeYouTube(pausedTabs);
+        log(`Speaking finished, resumed ${pausedTabs.length} tab(s)`);
+        pausedTabs = [];
+      }
+      scheduleSpotifyRestore();
     }
 
     wasReading = isReading;
@@ -42,6 +64,88 @@ async function pollStatus() {
         pausedTabs = [];
       }
     }
+    // Listener gone — restore immediately rather than waiting out the hold.
+    if (restoreTimer) {
+      clearTimeout(restoreTimer);
+      restoreTimer = null;
+    }
+    if (duckedTabs.length > 0) {
+      const tabs = duckedTabs;
+      duckedTabs = [];
+      await restoreSpotify(tabs);
+    }
+  }
+}
+
+function scheduleSpotifyRestore() {
+  if (restoreTimer || duckedTabs.length === 0) return;
+  restoreTimer = setTimeout(async () => {
+    restoreTimer = null;
+    const tabs = duckedTabs;
+    duckedTabs = [];
+    await restoreSpotify(tabs);
+    log(`Restored volume on ${tabs.length} Spotify tab(s)`);
+  }, RESTORE_HOLD_MS);
+}
+
+async function duckSpotify() {
+  const tabs = await chrome.tabs.query({ url: ["https://open.spotify.com/*"] });
+
+  const ducked = [];
+  for (const tab of tabs) {
+    if (!tab.id) continue;
+    try {
+      const [{ result } = {}] = await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: (duckVolume, fadeMs) => {
+          const media = [...document.querySelectorAll("video, audio")].find(
+            el => !el.paused && !el.ended && el.readyState >= 2 && el.volume > duckVolume
+          );
+          if (!media) return null;
+          const from = media.volume;
+          const start = performance.now();
+          const step = now => {
+            const t = Math.min((now - start) / fadeMs, 1);
+            media.volume = from + (duckVolume - from) * t;
+            if (t < 1) requestAnimationFrame(step);
+          };
+          requestAnimationFrame(step);
+          return from;
+        },
+        args: [DUCK_VOLUME, FADE_DOWN_MS]
+      });
+      if (result !== null && result !== undefined) {
+        ducked.push({ tabId: tab.id, volume: result });
+      }
+    } catch {}
+  }
+  return ducked;
+}
+
+async function restoreSpotify(tabs) {
+  for (const { tabId, volume } of tabs) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (!tab?.url?.startsWith("https://open.spotify.com/")) continue;
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        func: (targetVolume, fadeMs) => {
+          // Restore even if playback was paused mid-speech, so the next
+          // play resumes at the original volume.
+          const media = document.querySelector("video, audio");
+          if (!media || media.volume >= targetVolume) return;
+          const from = media.volume;
+          const start = performance.now();
+          const step = now => {
+            const t = Math.min((now - start) / fadeMs, 1);
+            media.volume = from + (targetVolume - from) * t;
+            if (t < 1) requestAnimationFrame(step);
+          };
+          requestAnimationFrame(step);
+        },
+        args: [volume, FADE_UP_MS]
+      });
+    } catch {}
   }
 }
 
@@ -107,6 +211,15 @@ function stopPolling() {
   if (pollTimer) {
     clearInterval(pollTimer);
     pollTimer = null;
+  }
+  if (restoreTimer) {
+    clearTimeout(restoreTimer);
+    restoreTimer = null;
+  }
+  if (duckedTabs.length > 0) {
+    const tabs = duckedTabs;
+    duckedTabs = [];
+    void restoreSpotify(tabs);
   }
   log("Polling stopped");
 }


### PR DESCRIPTION
## What

The extension already paused YouTube while VoxClaw spoke, but Spotify web playback was left at full volume, so speech competed with the music. This fades playing `open.spotify.com` tabs down to 20% for the duration of the speech, then restores each tab's *original* volume (300ms down, 500ms up). YouTube's pause/resume behavior is unchanged.

## Notes

- **Restore is held 1.5s** (`RESTORE_HOLD_MS`). `/status` reports `reading:false` during the speech queue's 1s inter-item gap, so without the hold the volume yo-yos between queued utterances.
- Volume is also restored if the VoxClaw listener disappears mid-speech or polling is toggled off, so a tab is never left stuck quiet.
- Each tab's original volume is preserved per-tab; tabs already at or below the duck level are left alone.
- Ducking moves Spotify's own volume slider, since that slider reads `element.volume` — the dip is visible in the UI, not just audible.
- Tunables are the four constants at the top of `service_worker.js`.

## Verification

- Fade math simulated against a stepped `requestAnimationFrame` clock: ducks to exactly 0.2, restores to the original 0.85, and skips elements already quieter than the duck level.
- Probed Spotify's real DOM via an instrumented build: the player is a media element in the **main document** (`shallow=1, deep=1, readyState=4`), so `querySelectorAll("video, audio")` reaches it with no shadow-DOM traversal.
- Installed unpacked in Dia (Chromium 150) and confirmed the service worker polls `/status` at a steady 1Hz against a running VoxClaw.
- Not exercised: the `!media.paused` gate, i.e. ducking during actual playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)