### PR TITLE
Close the socket after each response instead of leaking a descriptor

### DIFF
--- a/Sources/VoxClawCore/Network/NetworkSession.swift
+++ b/Sources/VoxClawCore/Network/NetworkSession.swift
@@ -331,13 +331,17 @@ final class NetworkSession: Sendable {
             headers += "\r\n"
             var responseData = headers.data(using: .utf8) ?? Data()
             responseData.append(bodyData)
-            connection.send(content: responseData, completion: .contentProcessed { [weak self] _ in
-                self?.connection.cancel()
+            // Capture the connection, not self: nothing retains the session past
+            // the receive handler, so a `weak self` here is usually already nil by
+            // the time the send completes and the socket is never closed (leaking
+            // one fd per request until the listener stops accepting entirely).
+            connection.send(content: responseData, completion: .contentProcessed { [connection] _ in
+                connection.cancel()
             })
         } else {
             headers += "\r\n"
-            connection.send(content: headers.data(using: .utf8), completion: .contentProcessed { [weak self] _ in
-                self?.connection.cancel()
+            connection.send(content: headers.data(using: .utf8), completion: .contentProcessed { [connection] _ in
+                connection.cancel()
             })
         }
     }

--- a/Tests/VoxClawCoreTests/NetworkListenerIntegrationTests.swift
+++ b/Tests/VoxClawCoreTests/NetworkListenerIntegrationTests.swift
@@ -38,6 +38,51 @@ struct NetworkListenerIntegrationTests {
         #expect(!body.contains(".local"))
     }
 
+    /// Each served request must close its socket. The session that owns the
+    /// connection is not retained past its receive handler, so a response path
+    /// that cancels via `weak self` silently leaks one descriptor per request
+    /// and the listener eventually stops accepting entirely.
+    @Test func servedRequestsDoNotLeakDescriptors() async throws {
+        let appState = AppState()
+        let settings = SettingsManager()
+        let listener = NetworkListener(port: Self.testPort, serviceName: nil, appState: appState, settings: settings)
+
+        try listener.start(onReadRequest: { _ in })
+        defer { listener.stop() }
+
+        try await waitForListener(port: Self.testPort)
+
+        let url = URL(string: "http://localhost:\(Self.testPort)/status")!
+        // Don't let URLSession pool connections; we want each request's server-side
+        // socket to be the only thing that could accumulate.
+        let config = URLSessionConfiguration.ephemeral
+        config.httpShouldUsePipelining = false
+        let session = URLSession(configuration: config)
+        defer { session.invalidateAndCancel() }
+
+        // Warm up so one-time allocations aren't counted as growth.
+        for _ in 0..<10 { _ = try await session.data(from: url) }
+        let before = Self.openDescriptorCount()
+
+        let requestCount = 200
+        for _ in 0..<requestCount { _ = try await session.data(from: url) }
+        try await Task.sleep(for: .milliseconds(500))
+
+        let growth = Self.openDescriptorCount() - before
+        // Leaking would grow roughly 1:1 with requests. Allow generous headroom
+        // for client-side sockets still winding down.
+        #expect(growth < requestCount / 4, "descriptor count grew by \(growth) over \(requestCount) requests")
+
+        // And the listener must still be answering after the burst.
+        let (_, response) = try await session.data(from: url)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    }
+
+    /// Open file descriptors for the current process.
+    private static func openDescriptorCount() -> Int {
+        (try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count) ?? 0
+    }
+
     @Test func readEndpointAcceptsJSON() async throws {
         let appState = AppState()
         let settings = SettingsManager()


### PR DESCRIPTION
## The bug

`NetworkSession` is created per connection, and **nothing retains it** — `NetworkListener` makes it a local, calls `start()`, and lets it go. The only strong reference is the `[self]` capture inside the receive handler, which is released as soon as that handler returns.

The response path then cancelled the connection through `weak self`:

```swift
connection.send(content: responseData, completion: .contentProcessed { [weak self] _ in
    self?.connection.cancel()   // self is usually already nil here
})
```

So `NWConnection.cancel()` typically never ran, and **every served request leaked one file descriptor**.

## Why it matters

The app runs against a 256 soft file limit. A client polling `GET /status` once a second — which the bundled browser extension does — exhausts that in well under an hour.

Observed on a live instance: **2,532 sockets stuck in `(CLOSED)`**, 2,625 descriptors held, and the listener silently refusing new connections while the menu bar app looked perfectly healthy. Restarting the app "fixes" it until the count climbs again, which makes it easy to misread as a network or firewall problem.

## The fix

Capture the connection instead of the session, so cancellation can't depend on session lifetime:

```swift
completion: .contentProcessed { [connection] _ in connection.cancel() }
```

## Verification

The new test counts the test process's own open descriptors (via `/dev/fd`) across a burst of requests, then confirms the listener still answers afterward.

- Against the previous code it fails with **"descriptor count grew by 200 over 200 requests"** — a clean 1:1 leak.
- With the fix, growth stays near zero and the post-burst request returns 200.
- Full suite: 280 tests in 35 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)