### PR TITLE
Keep the extension polling across a VoxClaw restart

### DIFF
--- a/BrowserExtension/manifest.json
+++ b/BrowserExtension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "VoxClaw",
   "description": "Pauses YouTube and ducks Spotify when VoxClaw speaks, restores when it finishes.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",
@@ -12,7 +12,8 @@
   "permissions": [
     "tabs",
     "scripting",
-    "storage"
+    "storage",
+    "alarms"
   ],
   "host_permissions": [
     "http://localhost:4140/*",

--- a/BrowserExtension/service_worker.js
+++ b/BrowserExtension/service_worker.js
@@ -57,6 +57,13 @@ async function pollStatus() {
 
     wasReading = isReading;
   } catch {
+    // This chrome.* call is load-bearing beyond the title it sets: extension API
+    // activity is what resets the service worker's idle timer. The success path
+    // above calls chrome.action every second, but without a call here the worker
+    // goes idle while VoxClaw is unreachable and is torn down — taking the poll
+    // interval with it, so ducking never resumes once VoxClaw comes back.
+    chrome.action.setTitle({ title: "VoxClaw (not running)" });
+
     if (wasReading) {
       wasReading = false;
       if (pausedTabs.length > 0) {
@@ -223,6 +230,23 @@ function stopPolling() {
   }
   log("Polling stopped");
 }
+
+// A service worker is torn down after ~30s without extension API activity.
+// While VoxClaw is unreachable pollStatus takes its catch path, which makes no
+// chrome.* calls, so the worker dies — and setInterval dies with it. Nothing
+// would restart it, because startPolling only runs on install/startup, so a
+// single VoxClaw restart used to disable the extension until the browser was
+// restarted. This alarm wakes the worker back up and restarts the loop.
+const WATCHDOG_ALARM = "voxclaw-poll-watchdog";
+// 30s is the shortest period Chrome honors for alarms.
+chrome.alarms.create(WATCHDOG_ALARM, { periodInMinutes: 0.5 });
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name !== WATCHDOG_ALARM) return;
+  chrome.storage.local.get("enabled", ({ enabled }) => {
+    if (enabled !== false) startPolling();
+  });
+});
 
 chrome.storage.local.get("enabled", ({ enabled }) => {
   if (enabled !== false) startPolling();


### PR DESCRIPTION
## The bug

The poll loop is a `setInterval` inside an MV3 service worker, which Chrome tears down after ~30s without extension API activity.

The success path calls `chrome.action.setIcon`/`setTitle` every second, which keeps the worker alive. **The catch path — taken whenever VoxClaw is unreachable — made no `chrome.*` calls at all.** So:

1. VoxClaw quits or restarts → `fetch` throws → catch path, no API activity
2. ~30s later the worker is torn down, and `setInterval` dies with it
3. Nothing ever restarts it: `startPolling` only runs on install/startup/storage-change
4. Ducking is dead until the **browser** is restarted

Observed directly while testing #10: after restarting VoxClaw, the listener answered `200` while the extension made **zero requests across a 15s window**, and stayed silent indefinitely.

This is pre-existing — it applies equally to the YouTube pausing that shipped before Spotify ducking — but it is much more visible now that the extension is actually installed and relied on.

## The fix

Two independent guards, because the failure mode is completely silent:

- **`chrome.action.setTitle` in the catch path** — the worker survives the outage instead of needing resurrection, and the toolbar now shows "VoxClaw (not running)". The API call is load-bearing beyond the title it sets; there's a comment saying so, since it looks removable.
- **A 30s `chrome.alarms` watchdog** that restarts polling if the worker was torn down anyway (browser idle, crash, sleep). `startPolling` is already idempotent via its `pollTimer` guard. Adds the `alarms` permission.

## Verification

Verified against a running browser (Dia, Chromium 150), reproducing the exact failure:

1. Reloaded the extension and confirmed the new worker actually registered — `service_worker_registration_info.version` went 1.1.0 → **1.1.1**, and `serviceworkerevents` gained **`alarms.onAlarm`**. (This check matters: a browser restart picks up new manifest *permissions* while still running the *old* worker script, which invalidated an earlier attempt at this test.)
2. Quit VoxClaw, waited 70s with the listener down — past the ~30s teardown window that previously killed polling for good.
3. Relaunched VoxClaw.

Result: **75 requests in 75 seconds**, a steady 1 Hz resuming ~12s after the listener returned. Against the previous code the same sequence produced zero requests, permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)